### PR TITLE
環境構築のワンライナーshellを追加

### DIFF
--- a/dotfiles_link.sh
+++ b/dotfiles_link.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+ln -sf ~/git/dotfiles/.pryrc ~/.pryrc
+ln -sf ~/git/dotfiles/.zshrc ~/.zshrc


### PR DESCRIPTION
Unix 向けの環境構築コマンドを追加。

```
./dotfiles_link.sh
```

で、 `~/git/dotfiles/.*` をシンボリックリンクで紐づけます。