### PR TITLE
puma の gem install でエラーが発生しないように調整

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -2,3 +2,4 @@
 BUNDLE_PATH: "vendor/bundle"
 BUNDLE_JOBS: "4"
 BUNDLE_BUILD__MYSQL2: "--with-ldflags=-L/usr/local/opt/openssl/lib"
+BUNDLE_BUILD__PUMA: "--with-cflags=-Wno-error=implicit-function-declaration"


### PR DESCRIPTION
## 概要
 - bundle config の設定で puma のバージョン差異による install error が起こらないように調整