### PR TITLE
feat: wt コマンドで fzf を使ってベースブランチを選択できるように改善

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -130,8 +130,8 @@ wt() {
 
     base_ref="$(
       {
-        [ "$is_detached" -eq 0 ] && echo "$current_branch"
-        git branch -a --format='%(refname:short)' | grep -vF "$current_branch" | grep -v 'HEAD$'
+        echo "$current_branch"
+        git branch -a --format='%(refname:short)' | grep -vxF "$current_branch" | grep -v 'HEAD$'
       } | fzf --prompt="base> " --header="$fzf_header"
     )" || { echo "Canceled"; return 0; }
 

--- a/.zshrc
+++ b/.zshrc
@@ -111,14 +111,20 @@ wt() {
 
   # Create new
   if [ "$wt_branch" = "(+)" ]; then
-    local br base_ref wt_root dir_safe new_dir
+    local br base_ref wt_root dir_safe new_dir current_branch
 
     printf "New branch name (e.g. feat/login-fix): "
     IFS= read -r br
     [ -z "$br" ] && { echo "Canceled"; return 0; }
 
-    # base = current branch (or current commit if detached)
-    base_ref="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || git rev-parse --short HEAD)"
+    current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || git rev-parse --short HEAD)"
+
+    base_ref="$(
+      {
+        echo "$current_branch"
+        git branch -a --format='%(refname:short)' | grep -v "^${current_branch}$"
+      } | fzf --prompt="base> " --header="Base branch (default: $current_branch)"
+    )" || base_ref="$current_branch"
 
     wt_root="../wt"
     mkdir -p "$wt_root" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- 新規ワークツリー作成時に、ベースブランチを fzf で選択できるように変更
- 従来は現在のブランチに固定されていた `base_ref` を、全ブランチ一覧から対話的に選択可能に
- 現在のブランチがデフォルト先頭に表示され、キャンセル時は現在のブランチをフォールバックとして使用

## Test plan

- [ ] `wt` コマンドを実行し `(+)` を選択
- [ ] ブランチ名を入力後、fzf でベースブランチ選択画面が表示されることを確認
- [ ] 別のブランチを選択してワークツリーが正しいベースで作成されることを確認
- [ ] `Ctrl+C` でキャンセルした場合に現在のブランチが使用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)