### PR TITLE
fix: Apple Silicon 向けに Homebrew パスを /opt/homebrew へ移行し bun を追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -5,18 +5,15 @@ export LSCOLORS=Dxfxcxdxbxegedabagacad
 export PS1="%n %~ \$ "
 
 # Homebrew
-export PATH=/usr/local/bin:$PATH
-export PATH=/usr/local/sbin:$PATH
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 
-# python
-export PATH="$HOME/.pyenv/bin:$PATH"
+# python (Homebrew: /opt/homebrew/bin/pyenv)
 eval "$(pyenv init -)"
 
-# rbenv
-export PATH="$HOME/.rbenv/shims:${PATH}"
+# rbenv (Homebrew: /opt/homebrew/bin/rbenv)
 eval "$(rbenv init -)"
 
-# nodenv
+# nodenv (git clone: ~/.nodenv/bin, or Homebrew: /opt/homebrew/bin/nodenv)
 export PATH="$HOME/.nodenv/bin:$PATH"
 eval "$(nodenv init -)"
 
@@ -195,10 +192,10 @@ wtrm() {
   git worktree prune >/dev/null 2>&1 || true
 }
 
-export PATH="/usr/local/opt/openssl@3/bin:$PATH"
-export LDFLAGS="-L/usr/local/opt/openssl@3/lib"
-export CPPFLAGS="-I/usr/local/opt/openssl@3/include"
-export PATH="/usr/local/opt/postgresql@17/bin:$PATH"
+export PATH="/opt/homebrew/opt/openssl@3/bin:$PATH"
+export LDFLAGS="-L/opt/homebrew/opt/openssl@3/lib"
+export CPPFLAGS="-I/opt/homebrew/opt/openssl@3/include"
+export PATH="/opt/homebrew/opt/postgresql@17/bin:$PATH"
 
 # Added by Antigravity
 export PATH="/Users/chinju/.antigravity/antigravity/bin:$PATH"

--- a/.zshrc
+++ b/.zshrc
@@ -200,3 +200,10 @@ export PATH="/opt/homebrew/opt/postgresql@17/bin:$PATH"
 # Added by Antigravity
 export PATH="/Users/chinju/.antigravity/antigravity/bin:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
+
+# bun completions
+[ -s "/Users/chinju/.bun/_bun" ] && source "/Users/chinju/.bun/_bun"
+
+# bun
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"


### PR DESCRIPTION
## Summary

- `/usr/local` から `/opt/homebrew` へ Homebrew パスを移行（Apple Silicon 対応）
- pyenv・rbenv の明示的 PATH 設定を削除し `init` のみに整理
- openssl@3・postgresql@17 の LDFLAGS/CPPFLAGS も `/opt/homebrew` へ更新
- bun の `BUN_INSTALL`、`PATH`、zsh 補完スクリプトを追加

## Test plan

- [ ] `echo $PATH` で `/opt/homebrew/bin` が含まれることを確認
- [ ] `pyenv`, `rbenv`, `nodenv` が正常に動作することを確認
- [ ] `openssl version` が Homebrew の openssl@3 を参照することを確認
- [ ] `bun --version` が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)