### PR TITLE
feat: チーム用 Cursor を cursor-team で起動できるようにする

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -24,6 +24,22 @@ alias ls='ls -G'
 alias rs='be rails s -b 0.0.0.0'
 alias :q='exit'
 
+# Cursor: 普段は PATH の `cursor`。チーム用アカウントは別ユーザーデータで `cursor-team`。
+export CURSOR_TEAM_USER_DATA_DIR="${CURSOR_TEAM_USER_DATA_DIR:-$HOME/Library/Application Support/Cursor-team}"
+
+cursor-team() {
+  local bin
+  bin="$(whence -p cursor 2>/dev/null)"
+  if [ -z "$bin" ]; then
+    bin="/Applications/Cursor.app/Contents/Resources/app/bin/cursor"
+  fi
+  if [ ! -x "$bin" ]; then
+    echo "cursor not found" >&2
+    return 1
+  fi
+  "$bin" --user-data-dir "$CURSOR_TEAM_USER_DATA_DIR" "$@"
+}
+
 # alias:cd
 alias cdd="cd $HOME/Desktop"
 


### PR DESCRIPTION
## Summary
- 同一端末で、普段の `cursor` と別ユーザーデータ（別ログイン・例: チーム用メール）を切り替えたい。
- `cursor` CLI の `--user-data-dir` でデータを分離する `cursor-team` シェル関数を追加した。

## Changes
- `CURSOR_TEAM_USER_DATA_DIR` を用意（未設定時は `~/Library/Application Support/Cursor-team`）。
- `cursor-team` が `whence -p cursor`、なければ `/Applications/Cursor.app/.../bin/cursor` を実行し、上記ディレクトリで起動する。

## Test plan
- `source ~/.zshrc` のあと `cursor-team .` でウィンドウが開き、チーム用アカウントでログインできること。
- 従来どおり `cursor` は PATH 経由でメイン用データのまま動くこと。

Made with [Cursor](https://cursor.com)