### PR TITLE
fix: mysql2 の OpenSSL リンク設定を削除

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,6 +1,5 @@
 ---
 BUNDLE_PATH: "vendor/bundle"
 BUNDLE_JOBS: "4"
-BUNDLE_BUILD__MYSQL2: "--with-ldflags=-L/usr/local/opt/openssl/lib"
 BUNDLE_LOCAL: "jobs 4"
 BUNDLE_BUILD__PUMA: "CC=clang -fdeclspec"


### PR DESCRIPTION
## Summary
- Bundler の `BUNDLE_BUILD__MYSQL2` に含まれていた Homebrew openssl パス依存を削除する
- 環境によっては不要または `bundle install` 失敗の原因になるため、設定を整理する

## Changes
- `.bundle/config` から `BUNDLE_BUILD__MYSQL2: "--with-ldflags=-L/usr/local/opt/openssl/lib"` を削除

## Test plan
- [ ] 対象プロジェクトで `bundle install` が問題なく完了することを確認
- [ ] mysql2 を使うプロジェクトでは、必要に応じて環境に合ったビルドオプションを別途設定する

Made with [Cursor](https://cursor.com)