### PR TITLE
feat: cursor-profile を導入し wt から直接起動する

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -23,6 +23,7 @@ alias bi='bundle install'
 alias ls='ls -G'
 alias rs='be rails s -b 0.0.0.0'
 alias :q='exit'
+alias c='clear'
 
 # Cursor: 普段は PATH の `cursor`。別アカウントは `cursor-profile`（fzf でプロファイル選択、以降は cursor と同じ引数）。
 # プロファイル定義はリポジトリ外（既定: ~/.cursor-profiles.zsh、CURSOR_PROFILES_FILE で変更可）
@@ -231,12 +232,12 @@ _cursor_profile_pick() {
       done
     } | fzf --prompt="profile> " --with-nth=2 --delimiter="$(printf '\t')" \
            --header="Choose Cursor profile / Select (+) to create"
-  )" || return 1
+  )" || return $?
 
   picked="${picked%%$'\t'*}"
 
   if [ "$picked" = "(+)" ]; then
-    _cursor_profile_add || return 1
+    _cursor_profile_add || return $?
     picked="$_cursor_profile_last_added"
     [ -z "$picked" ] && return 1
   fi
@@ -273,7 +274,7 @@ Profiles are stored in ~/.cursor-profiles.zsh (or $CURSOR_PROFILES_FILE).
 EOF
       ;;
     *)
-      _cursor_profile_pick || return 1
+      _cursor_profile_pick || return $?
       profile="$_cursor_profile_picked"
       _cursor_profile_launch "$profile" "$@"
       ;;
@@ -315,7 +316,6 @@ alias fpush='git push -f origin HEAD'
 alias pull="git pull origin HEAD"
 alias show="git show"
 alias st="git stash"
-alias c="clear"
 
 wt() {
   emulate -L zsh
@@ -329,7 +329,13 @@ wt() {
   local orig_dir pick wt_branch wt_dir st
   orig_dir="$PWD"
 
-  typeset -f cursor-profile >/dev/null 2>&1 || { echo "cursor-profile not found"; return 1; }
+  _wt_open_cursor() {
+    typeset -f cursor-profile >/dev/null 2>&1 || {
+      echo "wt: cursor-profile not found" >&2
+      return 1
+    }
+    cursor-profile -n .
+  }
 
   # Build list (TAB-separated): branch<TAB>dir
   pick="$(
@@ -408,12 +414,17 @@ wt() {
     fi
 
     cd "$new_dir" || { cd "$orig_dir"; return 1; }
-    cursor-profile -n . || {
+    _wt_open_cursor || {
       st=$?
       cd "$orig_dir" || true
-      [ -d "$new_dir" ] && echo "wt: worktree path: $new_dir" >&2
-      if [ "$did_add" -eq 1 ]; then
-        git worktree remove "$new_dir" 2>/dev/null || echo "wt: could not remove new worktree automatically: $new_dir" >&2
+      if [ "$st" -eq 130 ]; then
+        echo "wt: profile selection canceled" >&2
+        if [ "$did_add" -eq 1 ]; then
+          [ -d "$new_dir" ] && echo "wt: worktree path: $new_dir" >&2
+          git worktree remove "$new_dir" 2>/dev/null || echo "wt: could not remove new worktree automatically: $new_dir" >&2
+        fi
+      elif [ -d "$new_dir" ]; then
+        echo "wt: worktree path: $new_dir" >&2
       fi
       return "$st"
     }
@@ -424,9 +435,10 @@ wt() {
   # Open existing
   [ -z "$wt_dir" ] && return 0
   cd "$wt_dir" || { cd "$orig_dir"; return 1; }
-  cursor-profile -n . || {
+  _wt_open_cursor || {
     st=$?
     cd "$orig_dir" || true
+    [ "$st" -eq 130 ] && echo "wt: profile selection canceled" >&2
     return "$st"
   }
   cd "$orig_dir" || true

--- a/.zshrc
+++ b/.zshrc
@@ -315,6 +315,7 @@ alias fpush='git push -f origin HEAD'
 alias pull="git pull origin HEAD"
 alias show="git show"
 alias st="git stash"
+alias c="clear"
 
 wt() {
   emulate -L zsh

--- a/.zshrc
+++ b/.zshrc
@@ -176,7 +176,11 @@ _cursor_profile_rm() {
         printf "%s\t%s\n" "$n" "$d"
       done | fzf --prompt="remove> " --with-nth=1,2 --delimiter="$(printf '\t')" \
              --header="Choose profile to remove"
-    )" || return 1
+    )" || {
+      local ret=$?
+      [[ $ret == 1 || $ret == 130 ]] && return 130
+      return $ret
+    }
     name="${name%%$'\t'*}"
   fi
 
@@ -232,7 +236,11 @@ _cursor_profile_pick() {
       done
     } | fzf --prompt="profile> " --with-nth=2 --delimiter="$(printf '\t')" \
            --header="Choose Cursor profile / Select (+) to create"
-  )" || return $?
+  )" || {
+    local ret=$?
+    [[ $ret == 1 || $ret == 130 ]] && return 130
+    return $ret
+  }
 
   picked="${picked%%$'\t'*}"
 

--- a/.zshrc
+++ b/.zshrc
@@ -325,50 +325,10 @@ wt() {
   command -v fzf >/dev/null 2>&1 || { echo "fzf not found"; return 1; }
   git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "Not a git repo"; return 1; }
 
-  local orig_dir pick wt_branch wt_dir opener st
+  local orig_dir pick wt_branch wt_dir st
   orig_dir="$PWD"
 
-  # fzf で cursor / cursor-profile / code を選ぶ（1列目がコマンド種別）
-  _wt_pick_opener() {
-    local line
-    line="$(
-      {
-        printf "cursor\tCursor (default)\n"
-        if typeset -f cursor-profile >/dev/null 2>&1; then
-          printf "cursor-profile\tCursor (profile)\n"
-        fi
-        if command -v code >/dev/null 2>&1; then
-          printf "code\tVisual Studio Code\n"
-        fi
-      } | fzf --prompt="open> " --with-nth=2 --delimiter="$(printf '\t')" \
-             --header="Choose how to open this worktree"
-    )" || return 1
-    print -r -- "${line%%$'\t'*}"
-  }
-
-  _wt_run_opener() {
-    local kind="$1"
-    case "$kind" in
-      cursor)
-        if command -v cursor >/dev/null 2>&1; then
-          cursor -n .
-        else
-          echo "cursor not in PATH" >&2
-          return 1
-        fi
-        ;;
-      cursor-profile)
-        cursor-profile -n . || return 1
-        ;;
-      code)
-        command -v code >/dev/null 2>&1 && code -n . || return 1
-        ;;
-      *)
-        echo "wt: unknown opener: $kind" >&2
-        return 1
-        ;;
-    esac
-  }
+  typeset -f cursor-profile >/dev/null 2>&1 || { echo "cursor-profile not found"; return 1; }
 
   # Build list (TAB-separated): branch<TAB>dir
   pick="$(
@@ -446,33 +406,29 @@ wt() {
       did_add=1
     fi
 
-    opener="$(_wt_pick_opener)" || {
-      echo "wt: opener selection canceled" >&2
+    cd "$new_dir" || { cd "$orig_dir"; return 1; }
+    cursor-profile -n . || {
+      st=$?
+      cd "$orig_dir" || true
       [ -d "$new_dir" ] && echo "wt: worktree path: $new_dir" >&2
       if [ "$did_add" -eq 1 ]; then
         git worktree remove "$new_dir" 2>/dev/null || echo "wt: could not remove new worktree automatically: $new_dir" >&2
       fi
-      return 1
+      return "$st"
     }
-    cd "$new_dir" || { cd "$orig_dir"; return 1; }
-    _wt_run_opener "$opener"
-    st=$?
     cd "$orig_dir" || true
-    [ $st -ne 0 ] && return "$st"
     return 0
   fi
 
   # Open existing
   [ -z "$wt_dir" ] && return 0
-  opener="$(_wt_pick_opener)" || {
-    echo "wt: opener selection canceled" >&2
-    return 1
-  }
   cd "$wt_dir" || { cd "$orig_dir"; return 1; }
-  _wt_run_opener "$opener"
-  st=$?
+  cursor-profile -n . || {
+    st=$?
+    cd "$orig_dir" || true
+    return "$st"
+  }
   cd "$orig_dir" || true
-  [ $st -ne 0 ] && return "$st"
   return 0
 }
 

--- a/.zshrc
+++ b/.zshrc
@@ -121,7 +121,7 @@ EOF
     fi
     printf "Profile name (e.g. team, work; letters, numbers, _, - only): " >&2
     IFS= read -r name
-    [ -z "$name" ] && { echo "Canceled" >&2; return 1; }
+    [ -z "$name" ] && { echo "Canceled" >&2; return 130; }
   fi
 
   if [[ ! "$name" =~ ^[a-zA-Z0-9_-]+$ ]]; then


### PR DESCRIPTION
## Summary
- `cursor-team` を廃止し、`cursor-profile` で複数 Cursor プロファイルを fzf 管理できるようにした
- `wt` の worktree オープン時に IDE 選択を廃止し、常に `cursor-profile -n .` を直接起動するようにした
- プロファイル選択キャンセル時のみ新規 worktree を巻き戻し、起動失敗時は worktree を保持するようにした

## Changes
- `cursor-profile` コマンド（add / rm / list / fzf 選択起動）とプロファイル定義ファイル（`~/.cursor-profiles.zsh`）の読み書き
- `wt` から `_wt_pick_opener` / `_wt_run_opener` を削除し、`_wt_open_cursor` 経由で `cursor-profile -n .` を起動
- fzf キャンセル（Esc / Ctrl+C）を終了コード 130 に正規化し、キャンセルと起動失敗を区別
- プロファイル名入力キャンセル（`(+) create` フロー）も 130 として wt に伝播
- `alias c='clear'` を一般 alias ブロックに追加

## Test plan
- [ ] リポジトリ内で `wt` を実行し、worktree 選択後にプロファイル fzf が表示され、選択したプロファイルで Cursor が新規ウィンドウ起動すること
- [ ] `wt` で新規 worktree 作成後、プロファイル fzf を Esc でキャンセルすると worktree が巻き戻されること
- [ ] プロファイル選択後に Cursor 起動が失敗した場合、worktree が残りパスが表示されること
- [ ] `(+)` でプロファイル作成中に名前入力をキャンセルした場合、新規 worktree が巻き戻されること
- [ ] `cursor-profile list` / `cursor-profile add` / `cursor-profile rm` が期待どおり動作すること
- [ ] `c` で画面がクリアされること
- [ ] `source ~/.zshrc` 後に既存の git エイリアス・`sw` / `wt` が問題なく動作すること